### PR TITLE
fix: [h5] double quote escape

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export function defineConfig<Theme extends {}>(config: WebpackPluginOptions<Them
 }
 
 // const styleCssRegExp = /\/\*\s*unocss-start\s*\*\/[\s\S]*\/\*\s*unocss-end\s*\*\//
-const styleCssRegExp = /.uno-start[\s\S]*.uno-end/
+const styleCssRegExp = /(\\n)?.uno-start[\s\S]*.uno-end/
 
 export default function WebpackPlugin<Theme extends {}>(
   configOrPath?: WebpackPluginOptions<Theme> | string,
@@ -69,12 +69,14 @@ export default function WebpackPlugin<Theme extends {}>(
               if (styleCssRegExp.test(code)) {
                 replaced = true
                 let css = result.getLayers()
-
                 if (process.env.UNI_PLATFORM === 'app-plus')
                   css = css.replace('page', 'body')
+                code = code.replace(styleCssRegExp, (_, newLine) => {
+                  if (newLine)
+                    css = JSON.stringify(css).slice(1, -1)
 
-                // code = code.replace(styleCssRegExp, `/* unocss-start */${css}/* unocss-end */`)
-                code = code.replace(styleCssRegExp, `.uno-start{--un: 0;}${css}.uno-end`)
+                  return `${newLine || ''}.uno-start{--un: 0;}${css}.uno-end`
+                })
               }
 
               if (replaced)


### PR DESCRIPTION
I find a bug, when I use class `content-empty` `font-mono` whose result css property value contains double quote `"`, and in `H5` environment, this plugin will cause an error.

The issue is caused by forgetting to handle quote escaping.

See [here](https://github.com/unocss/unocss/blob/d44d745f97c0d4c55dd45a625992d54235aadcda/packages/webpack/src/index.ts#L116C17-L123C65) of `@unocss/webpack`

It even handles cases like `eval()`, however, our case doesn't need that, so I only add handle for JS case.

And, in our case, `.uno-start` is different from `import 'uno.css'`, there can be anything before `.uno-start`, so the detection method is fragile, it force user to use a code template like this:
```html
<style>
.uno-start {}
.uno-end {}
</style>
```
Users must use a standalone `style` tag to wrap the placeholders.

